### PR TITLE
Refactored task model

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="50af4996-875b-47e8-85c5-3fe2104e6e1e" name="Default Changelist" comment="chang">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    <list default="true" id="50af4996-875b-47e8-85c5-3fe2104e6e1e" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/db.sqlite3" beforeDir="false" afterPath="$PROJECT_DIR$/db.sqlite3" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/serviceAccountKey.json" beforeDir="false" afterPath="$PROJECT_DIR$/serviceAccountKey.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tasks/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/admin.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tasks/forms.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/forms.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tasks/templates/tasks/list.html" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/templates/tasks/list.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tasks/templates/tasks/update_task.html" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/templates/tasks/update_task.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/tasks/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/views.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -66,7 +61,7 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1644480783683</updated>
-      <workItem from="1645596681349" duration="3885000" />
+      <workItem from="1645596681349" duration="4196000" />
     </task>
     <task id="LOCAL-00001" summary="refactored Task class into serializable class using dict">
       <created>1645629242110</created>
@@ -82,7 +77,28 @@
       <option name="project" value="LOCAL" />
       <updated>1645630519546</updated>
     </task>
-    <option name="localTasksCounter" value="3" />
+    <task id="LOCAL-00003" summary="automatically updated, don't know why">
+      <created>1645630615066</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1645630615066</updated>
+    </task>
+    <task id="LOCAL-00004" summary="no longer need to register Task class in admin">
+      <created>1645630684518</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1645630684518</updated>
+    </task>
+    <task id="LOCAL-00005" summary="commented out unused TaskForm">
+      <created>1645630731097</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1645630731097</updated>
+    </task>
+    <option name="localTasksCounter" value="6" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -102,6 +118,9 @@
   <component name="VcsManagerConfiguration">
     <MESSAGE value="refactored Task class into serializable class using dict" />
     <MESSAGE value="updated Task to have default val for complete and call super() constructor with self parameters" />
-    <option name="LAST_COMMIT_MESSAGE" value="updated Task to have default val for complete and call super() constructor with self parameters" />
+    <MESSAGE value="automatically updated, don't know why" />
+    <MESSAGE value="no longer need to register Task class in admin" />
+    <MESSAGE value="commented out unused TaskForm" />
+    <option name="LAST_COMMIT_MESSAGE" value="commented out unused TaskForm" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
-    <list default="true" id="50af4996-875b-47e8-85c5-3fe2104e6e1e" name="Default Changelist" comment="" />
+    <list default="true" id="50af4996-875b-47e8-85c5-3fe2104e6e1e" name="Default Changelist" comment="chang">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/db.sqlite3" beforeDir="false" afterPath="$PROJECT_DIR$/db.sqlite3" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/serviceAccountKey.json" beforeDir="false" afterPath="$PROJECT_DIR$/serviceAccountKey.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tasks/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/admin.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tasks/forms.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/forms.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tasks/templates/tasks/list.html" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/templates/tasks/list.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tasks/templates/tasks/update_task.html" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/templates/tasks/update_task.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tasks/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/tasks/views.py" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -15,16 +27,27 @@
       </list>
     </option>
   </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
   <component name="ProjectId" id="24uW7QZhpUXmrkFcfZBz8VLzXUq" />
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
-    <option name="showExcludedFiles" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
   <component name="PropertiesComponent">
     <property name="DefaultHtmlFileTemplate" value="HTML File" />
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
     <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="node.js.detected.package.eslint" value="true" />
+    <property name="node.js.detected.package.tslint" value="true" />
+    <property name="node.js.selected.package.eslint" value="(autodetect)" />
+    <property name="node.js.selected.package.tslint" value="(autodetect)" />
     <property name="settings.editor.selected.configurable" value="com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable" />
   </component>
   <component name="RecentsManager">
@@ -32,6 +55,7 @@
       <recent name="$PROJECT_DIR$/tasks/templates/tasks" />
     </key>
   </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="SvnConfiguration">
     <configuration />
   </component>
@@ -42,25 +66,42 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1644480783683</updated>
+      <workItem from="1645596681349" duration="3885000" />
     </task>
+    <task id="LOCAL-00001" summary="refactored Task class into serializable class using dict">
+      <created>1645629242110</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1645629242110</updated>
+    </task>
+    <task id="LOCAL-00002" summary="updated Task to have default val for complete and call super() constructor with self parameters">
+      <created>1645630519546</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1645630519546</updated>
+    </task>
+    <option name="localTasksCounter" value="3" />
     <servers />
   </component>
-  <component name="WindowStateProjectService">
-    <state x="184" y="109" key="#com.intellij.execution.impl.EditConfigurationsDialog" timestamp="1645080566641">
-      <screen x="0" y="0" width="1440" height="900" />
-    </state>
-    <state x="184" y="109" key="#com.intellij.execution.impl.EditConfigurationsDialog/0.0.1440.900@0.0.1440.900" timestamp="1645080566641" />
-    <state x="439" y="257" key="#com.intellij.fileTypes.FileTypeChooser" timestamp="1645048324546">
-      <screen x="0" y="0" width="1440" height="900" />
-    </state>
-    <state x="439" y="257" key="#com.intellij.fileTypes.FileTypeChooser/0.0.1440.900@0.0.1440.900" timestamp="1645048324546" />
-    <state x="229" y="86" key="SettingsEditor" timestamp="1644646983931">
-      <screen x="0" y="0" width="1440" height="900" />
-    </state>
-    <state x="229" y="86" key="SettingsEditor/0.0.1440.900@0.0.1440.900" timestamp="1644646983931" />
-    <state x="397" y="279" key="com.intellij.ide.util.TipDialog" timestamp="1645592472066">
-      <screen x="0" y="0" width="1440" height="900" />
-    </state>
-    <state x="397" y="279" key="com.intellij.ide.util.TipDialog/0.0.1440.900@0.0.1440.900" timestamp="1645592472066" />
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="refactored Task class into serializable class using dict" />
+    <MESSAGE value="updated Task to have default val for complete and call super() constructor with self parameters" />
+    <option name="LAST_COMMIT_MESSAGE" value="updated Task to have default val for complete and call super() constructor with self parameters" />
   </component>
 </project>

--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -2,5 +2,3 @@ from django.contrib import admin
 
 # Register your models here.
 from .models import *
-
-admin.site.register(Task)

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -2,8 +2,7 @@ from django import forms
 from django.forms import ModelForm
 from .models import *
 
-class TaskForm(forms.ModelForm):
-    class Meta:
-        model = Task
-        fields = '__all__'
-
+# class TaskForm(forms.ModelForm):
+#     class Meta:
+#         model = Task
+#         fields = '__all__'

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -1,10 +1,9 @@
-from django.db import models
-
 # Create your models here.
-class Task(models.Model):
-    title = models.CharField(max_length=200)
-    complete = models.BooleanField(default=False)
-    created = models.DateTimeField(auto_now_add=True)
 
-    def __str__(self):
-        return self.title
+class Task(dict):
+    def __init__(self, title, complete, created):
+        self.title = title
+        self.complete = complete
+        self.created = created
+        super().__init__(title=title, complete=complete, created=created)
+

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -1,9 +1,8 @@
 # Create your models here.
 
 class Task(dict):
-    def __init__(self, title, complete, created):
+    def __init__(self, title):
         self.title = title
-        self.complete = complete
-        self.created = created
-        super().__init__(title=title, complete=complete, created=created)
+        self.complete = False
+        super().__init__(title=self.title, complete=self.complete)
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -2,25 +2,22 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse, JsonResponse
 # Create your views here.
 from .models import *
-from .forms import *
 from .apps import FirestoreDB
 import json
 
 def index(request):
-    tasks = FirestoreDB.todo_collection.get()
-    taskdict = [task.to_dict() for task in tasks]
-    form = TaskForm()
-    context = {'tasks': taskdict,  'form': form}
-
 
     if request.method == "POST":
-        form = TaskForm(request.POST)
-        if form.is_valid():
-            data = form.cleaned_data
-            FirestoreDB.todo_collection.document(data["title"]).set(data)
-            # form.save()
-            return redirect('/')
-    return render(request, 'tasks/list.html', context)
+        # extract data from the post request
+        data = request.POST
+        title = data["title"]
+
+        # create Task object and save it in Firestore
+        task = Task(title)
+        FirestoreDB.todo_collection.document(title).set(task)
+        return redirect('/')
+
+    return render(request, 'tasks/list.html', {})
 
 
 def updateTask(request, pk):


### PR DESCRIPTION
- removed need for TaskForm
- refactored Task model to inherit from dict so it can be automatically serializable
- Using our serializable Task class, we will create a Task object when the user submits a Post request. 
- Then save this Task this object as data to Firestore using the title of the Task as the document name.

NOTE: I ONLY refactored the create functionality. The other functions, like update, will need to be refactored next using the foundation i laid out.